### PR TITLE
Fixed problems with backslash on Windows

### DIFF
--- a/tasks/es6_module_wrap_default.js
+++ b/tasks/es6_module_wrap_default.js
@@ -42,6 +42,9 @@ module.exports = function (grunt) {
 
       var importPath = path.join(path.relative(destDirname, srcDirname), srcBaseName);
 
+      // Path will use forward slash as delimiter on both Windows and Unix based systems.
+      importPath = path.normalize(importPath).replace(/\\/g, '/');
+
       var src;
 
       switch (options.type) {


### PR DESCRIPTION
I fixed the problems described in this issue:
https://github.com/stevoland/grunt-es6-module-wrap-default/issues/1

The path will now always have forward slashes, even on Windows machines.

I tested this on my Windows machine in the _react-bootstrap_ project and it seems to be working without any problems now.
