### PR TITLE
Fix MSIE8 compatbility problem due to 'default' being a reserved word.

### DIFF
--- a/tasks/es6_module_wrap_default.js
+++ b/tasks/es6_module_wrap_default.js
@@ -49,13 +49,13 @@ module.exports = function (grunt) {
 
       switch (options.type) {
         case 'cjs':
-          src = "var " + srcBaseName + " = require('./" + importPath + "').default;\n" +
+          src = "var " + srcBaseName + " = require('./" + importPath + "')['default'];\n" +
             "module.exports = " + srcBaseName;
           break;
 
         case 'amd':
           src = "define(['./" + importPath + "'], function (" + srcBaseName + ") {\n" +
-            "  return " + srcBaseName + ".default;\n" +
+            "  return " + srcBaseName + "['default'];\n" +
             "})";
           break;
       }


### PR DESCRIPTION
React-Bootstrap was failing in Microsoft IE8 due to this wrapper using the property `.default`.
According to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Reserved_Words `default` is a reserved word.

This is a workaround for accessing the property anyway.

Please note that I have no idea what I'm doing :)
